### PR TITLE
Throw exception if a duplicate state is added to the eventHandlers

### DIFF
--- a/src/main/kotlin/com.anupcowkur.statelin/State.kt
+++ b/src/main/kotlin/com.anupcowkur.statelin/State.kt
@@ -1,4 +1,8 @@
 package com.anupcowkur.statelin
 
 class State(private val name: String, internal val onEnter: (() -> Unit)? = null, internal val onExit: (() -> Unit)? = null) {
+
+    override fun hashCode() = name.hashCode()
+
+    override fun equals(other: Any?) = other is State && other.name == name
 }

--- a/src/test/kotlin/com/anupcowkur/statelin/MachineTest.kt
+++ b/src/test/kotlin/com/anupcowkur/statelin/MachineTest.kt
@@ -24,7 +24,8 @@ class MachineTest : StringSpec() {
         }
 
         "Should throw exception on duplicate trigger handlers" {
-            val stateA = State("A")
+            val stateA = State("A", {}, {})
+            val stateADuplicate = State("A", {}, {})
 
             val triggerX = Trigger("TriggerX")
 
@@ -35,7 +36,7 @@ class MachineTest : StringSpec() {
 
             val exception = shouldThrow<IllegalArgumentException> {
                 // Add same trigger handler again
-                machine.addTriggerHandler(TriggerHandler(stateA, triggerX, {}))
+                machine.addTriggerHandler(TriggerHandler(stateADuplicate, triggerX, {}))
             }
 
             exception.message shouldBe "TriggerHandler $stateA -> $triggerX is already added"


### PR DESCRIPTION
With the current implementation, exceptions aren't always thrown if a duplicate trigger handler is added. This is because the states are being compared by reference instead of by the contents of the object. Such a comparison is made [here](https://github.com/veyndan/statelin/blob/228662bc2e9e4da362504763352d83cfda10f5f0/src/main/kotlin/com.anupcowkur.statelin/Machine.kt#L31). By overriding the `.equals(Any?)` method of `State` this problem is now fixed. Note that `onEnter` and `onExit` aren't used in the comparison as these shouldn't be considered (hence the use of manually overriding `.equals(Any?)` and `hashCode()` compared to using a `data class`).