### PR TITLE
Use a set to explicitly indicate the absence of duplicates

### DIFF
--- a/src/main/kotlin/com.anupcowkur.statelin/Machine.kt
+++ b/src/main/kotlin/com.anupcowkur.statelin/Machine.kt
@@ -12,28 +12,16 @@ class Machine(state: State) {
             state.onEnter?.invoke()
         }
 
-    internal val eventHandlers = mutableListOf<TriggerHandler>()
+    internal val eventHandlers = mutableSetOf<TriggerHandler>()
 
     init {
         state.onEnter?.invoke()
     }
 
     fun addTriggerHandler(triggerHandler: TriggerHandler) {
-        if (isDuplicateTransition(triggerHandler)) {
+        if (!eventHandlers.add(triggerHandler)) {
             throw IllegalArgumentException("TriggerHandler ${triggerHandler.state} -> ${triggerHandler.trigger} is already added")
         }
-
-        eventHandlers.add(triggerHandler)
-    }
-
-    private fun isDuplicateTransition(triggerHandler: TriggerHandler): Boolean {
-        eventHandlers.forEach({
-            if (it.state == triggerHandler.state && it.trigger == triggerHandler.trigger) {
-                return true
-            }
-        })
-
-        return false
     }
 
     fun trigger(trigger: Trigger) {

--- a/src/main/kotlin/com.anupcowkur.statelin/TriggerHandler.kt
+++ b/src/main/kotlin/com.anupcowkur.statelin/TriggerHandler.kt
@@ -2,4 +2,9 @@ package com.anupcowkur.statelin
 
 data class TriggerHandler(val state: State,
                           val trigger: Trigger,
-                          val handler: () -> Unit)
+                          val handler: () -> Unit) {
+
+    override fun hashCode() = state.hashCode() * 31 + trigger.hashCode()
+
+    override fun equals(other: Any?) = other is TriggerHandler && other.state == state && other.trigger == trigger
+}


### PR DESCRIPTION
A set by definition can't have duplicates. Using a list and manually checking for duplicates is a bit cumbersome.

Overriding of `equals(Any?)` and `hashCode()` occurs as comparison by reference of the `TriggerHandler.handler` occurs otherwise.