### PR TITLE
Simplify trigger(Trigger) logic

### DIFF
--- a/src/main/kotlin/com.anupcowkur.statelin/Machine.kt
+++ b/src/main/kotlin/com.anupcowkur.statelin/Machine.kt
@@ -37,12 +37,7 @@ class Machine(state: State) {
     }
 
     fun trigger(trigger: Trigger) {
-        eventHandlers.forEach({
-            if (it.state == state && it.trigger == trigger) {
-                it.handler.invoke()
-                return
-            }
-        })
+        eventHandlers.firstOrNull { it.state == state && it.trigger == trigger }?.handler?.invoke()
     }
 
 }


### PR DESCRIPTION
This is more declarative IMO as it is obvious that a trigger-state pair may not be found in `eventHandlers`. Also the usage of `return` in a lambda to exit a function isn't very elegant.